### PR TITLE
Add authDevice

### DIFF
--- a/src/Connector.js
+++ b/src/Connector.js
@@ -114,6 +114,15 @@ class Connector {
     this.listenToCommands(newDevice.knot.id, client);
   }
 
+  async authDevice(id, token) {
+    try {
+      await this.createConnection(id, token);
+      return true;
+    } catch (err) {
+      return false;
+    }
+  }
+
   async removeDevice(id) {
     const thingClient = this.clientThings[id];
     thingClient.close();


### PR DESCRIPTION
Implement the `authDevice` method, needed to verify if a device is valid on the cloud.