### PR TITLE
github: Add action to publish library to NPM

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -1,0 +1,23 @@
+# This workflow will run linter using node and then publish the library to the NPM registry when a new release is created
+
+name: Publish to NPM
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish-npm:
+    name: Run linter and publish library to NPM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - run: yarn
+      - run: npm run lint
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR adds a github action to automate NPM library publication when a new release is created.
