### PR TITLE
Add update config (fog <-> cloud)

### DIFF
--- a/__mocks__/@cesarbr/knot-cloud-sdk-js-amqp.js
+++ b/__mocks__/@cesarbr/knot-cloud-sdk-js-amqp.js
@@ -2,6 +2,7 @@ export const mockConnect = jest.fn();
 export const mockRegister = jest.fn();
 export const mockUnregister = jest.fn();
 export const mockUpdateSchema = jest.fn();
+export const mockUpdateConfig = jest.fn();
 export const mockGetDevices = jest.fn();
 export const mockPublishData = jest.fn();
 export const mockOn = jest.fn();
@@ -32,6 +33,12 @@ export default jest.fn().mockImplementation((options = {}) => {
     mockUpdateSchema.mockRejectedValue(Error(options.updateSchemaErr));
   } else {
     mockUpdateSchema.mockResolvedValue();
+  }
+
+  if (options.updateConfigErr) {
+    mockUpdateConfig.mockRejectedValue(Error(options.updateConfigErr));
+  } else {
+    mockUpdateConfig.mockResolvedValue();
   }
 
   if (options.getDevicesErr) {
@@ -73,6 +80,7 @@ export default jest.fn().mockImplementation((options = {}) => {
     register: mockRegister,
     unregister: mockUnregister,
     updateSchema: mockUpdateSchema,
+    updateConfig: mockUpdateConfig,
     getDevices: mockGetDevices,
     publishData: mockPublishData,
     on: mockOn,

--- a/src/Connector.js
+++ b/src/Connector.js
@@ -78,6 +78,14 @@ class Connector {
     return this.client.updateSchema(id, schemaList);
   }
 
+  async updateConfig(id, configList) {
+    if (!this.devices.includes(id)) {
+      await this.registerListeners(id);
+      this.devices.push(id);
+    }
+    return this.client.updateConfig(id, configList);
+  }
+
   async publishData(id, dataList) {
     return this.client.publishData(id, dataList);
   }

--- a/src/Connector.js
+++ b/src/Connector.js
@@ -6,6 +6,7 @@ class Connector {
     const noop = () => undefined;
     this.onDataRequestedCb = noop;
     this.onDataUpdatedCb = noop;
+    this.onConfigUpdatedCb = noop;
     this.onDisconnectedCb = noop;
     this.onReconnectedCb = noop;
 
@@ -30,6 +31,11 @@ class Connector {
     await Promise.all(
       this.devices.map((device) => this.registerListeners(device))
     );
+
+    await this.client.on(`device.config.updated`, async (msg) => {
+      const { id, config } = msg;
+      this.onConfigUpdatedCb(id, config);
+    });
   }
 
   async registerListeners(thingId) {
@@ -86,6 +92,11 @@ class Connector {
   // cb(id, data)
   async onDataUpdated(cb) {
     this.onDataUpdatedCb = cb;
+  }
+
+  // cb(id, config)
+  async onConfigUpdated(cb) {
+    this.onConfigUpdatedCb = cb;
   }
 
   // Connection callbacks

--- a/src/Connector.test.js
+++ b/src/Connector.test.js
@@ -15,6 +15,15 @@ const mockThing = {
       name: 'bool-sensor',
     },
   ],
+  config: [
+    {
+      sensorId: 0,
+      change: true,
+      timeSec: 10,
+      lowerThreshold: 1000,
+      upperThreshold: 3000,
+    },
+  ],
 };
 const mockToken = 'authentication-token';
 const mockData = {
@@ -34,6 +43,7 @@ const errors = {
   addDevice: 'fail to create thing on cloud',
   removeDevice: 'fail to remove thing from cloud',
   updateSchema: 'fail to update thing schema in cloud',
+  updateConfig: 'fail to update thing config in cloud',
   publishData: 'fail to publish thing data to cloud',
 };
 
@@ -43,6 +53,7 @@ describe('Connector', () => {
     clientMocks.mockRegister.mockClear();
     clientMocks.mockUnregister.mockClear();
     clientMocks.mockUpdateSchema.mockClear();
+    clientMocks.mockUpdateConfig.mockClear();
     clientMocks.mockGetDevices.mockClear();
     clientMocks.mockPublishData.mockClear();
     clientMocks.mockOn.mockClear();
@@ -203,6 +214,33 @@ describe('Connector', () => {
       error = err.message;
     }
     expect(error).toBe(errors.updateSchema);
+  });
+
+  test("updateConfig: should update thing's config when connection is ok", async () => {
+    const client = new Client();
+    const connector = new Connector(client);
+    await connector.updateConfig(mockThing.id, mockThing.config);
+    expect(clientMocks.mockUpdateConfig).toHaveBeenCalled();
+  });
+
+  test("updateConfig: should register listeners when it's the first config", async () => {
+    const client = new Client();
+    const connector = new Connector(client);
+    await connector.updateConfig(mockThing.id, mockThing.config);
+    expect(connector.devices).toEqual([mockThing.id]);
+    expect(clientMocks.mockOn).toHaveBeenCalledTimes(2);
+  });
+
+  test("updateConfig: should fail to update thing's config when something goes wrong", async () => {
+    const client = new Client({ updateConfigErr: errors.updateConfig });
+    const connector = new Connector(client);
+    let error;
+    try {
+      await connector.updateConfig(mockThing.id, mockThing.config);
+    } catch (err) {
+      error = err.message;
+    }
+    expect(error).toBe(errors.updateConfig);
   });
 
   test('publishData: should publish data when connections is ok', async () => {

--- a/src/Connector.test.js
+++ b/src/Connector.test.js
@@ -24,6 +24,7 @@ const mockData = {
 const events = {
   request: `device.${mockThing.id}.data.request`,
   update: `device.${mockThing.id}.data.update`,
+  configUpdated: `device.config.updated`,
 };
 
 const errors = {
@@ -84,7 +85,7 @@ describe('Connector', () => {
     expect(connector.devices).toEqual([mockThing.id]);
     expect(clientMocks.mockGetDevices).toHaveBeenCalled();
     expect(clientMocks.mockOn).toHaveBeenCalledTimes(
-      registeredDevices.length * 2
+      registeredDevices.length * 2 + 1
     );
   });
 
@@ -256,6 +257,16 @@ describe('Connector', () => {
     await connector.registerListeners(mockThing.id);
     await connector.onDataUpdated(callback);
     client.executeHandler(events.update);
+    expect(callback).toHaveBeenCalled();
+  });
+
+  test('onConfigUpdated: should execute a callback when receives a config updated event', async () => {
+    const client = new Client();
+    const connector = new Connector(client);
+    const callback = jest.fn();
+    await connector.listenToCommands();
+    await connector.onConfigUpdated(callback);
+    client.executeHandler(events.configUpdated);
     expect(callback).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This patch adds two main features:

- subscribe to receive 'device.config.updated' events and call a callback defined by the connector service, which will update the thing's config on the KNoT Fog;
- `updateConfig` to be called by the connector service and update the thing's config on the KNoT Cloud.

Does this close any currently open issues?
------------------------------------------
Nops.

Any relevant logs, error output, etc?
-------------------------------------
Nops.

Where has this been tested?
---------------------------
(Describe your environment setup here.)

**Operating System/Platform:** macOS - Darwin 18.0.0

**NPM Version:** 6.14.4

**NodeJS Version:** v12.16.2